### PR TITLE
Content length fix (required for GA)

### DIFF
--- a/HttpMockPlayer/Player.cs
+++ b/HttpMockPlayer/Player.cs
@@ -494,6 +494,7 @@ namespace HttpMockPlayer
                             }
                             break;
                         case "Content-Length":
+                            request.ContentLength = long.Parse(value);
                             break;
                         case "Content-Type":
                             request.ContentType = value;


### PR DESCRIPTION
POST against http://www.google-analytics.com/collect will fail with "Content length missing". Seems like it's only set when the request has a body, which isn't the case here. Not sure if this change will break anything else, and if we can add a unit test for it?