### PR TITLE
Provide more details on why there's a request mismatch

### DIFF
--- a/HttpMockPlayer/Player.cs
+++ b/HttpMockPlayer/Player.cs
@@ -660,7 +660,7 @@ namespace HttpMockPlayer
                                             {
                                                 var differencesMessage = string.Join(", ",
                                                     differences.Select(d =>
-                                                        $"{d.Property} (Recorded={d.ThisValue}, Requested={d.OtherValue}"));
+                                                        $"{d.Property} (Recorded='{d.ThisValue}', Requested='{d.OtherValue}')"));
                                                 var message =
                                                     $"Player could not play the request at {playerRequest.Url.PathAndQuery}. " +
                                                     $"The request doesn't match the current recorded one: {differencesMessage}";


### PR DESCRIPTION
Will include list of diffing properties in error message:

`Player could not play the request at /invoices. The request doesn't match the current recorded one: Content (Recorded='...e xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"...', Requested='...e xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"...')`